### PR TITLE
to generate 'pandemic_output_aggregated.csv' with annual timestep

### DIFF
--- a/pandemic/model.py
+++ b/pandemic/model.py
@@ -10,6 +10,7 @@ from pandemic.helpers import create_trades_list
 from pandemic.model_equations import pandemic_multiple_time_steps
 from pandemic.output_files import (
     aggregate_monthly_output_to_annual,
+    write_annual_output,
     create_model_dirs,
     save_model_output,
     write_model_metadata,
@@ -183,6 +184,13 @@ for i in range(len(trades_list)):
         if len(date_list[i]) > 4:
             print("aggregating monthly predictions to annual time steps...")
             aggregate_monthly_output_to_annual(
+                formatted_geojson=full_out_df, outpath=outpath
+            )
+        
+        # If time steps are annual, export the predictions
+        if len(date_list[i]) == 4:
+            print("exporting annual predictions...")
+            write_annual_output(
                 formatted_geojson=full_out_df, outpath=outpath
             )
 

--- a/pandemic/output_files.py
+++ b/pandemic/output_files.py
@@ -355,6 +355,39 @@ def aggregate_monthly_output_to_annual(formatted_geojson, outpath):
     )
 
 
+def write_annual_output(formatted_geojson, outpath):
+    """
+    When the model is run with an annual timestep, export the annual
+    predictions of presence and probability of introduction
+    Parameters
+    ----------
+    formatted_geojson : geodataframe
+        Geodataframe containing original pandemic output as well as
+        additional columns with year: value dictionaries.
+    outpath : str
+        Directory path to save output (geojson and csv)
+    Returns
+    -------
+    none
+    """
+    prob_intro_cols = [
+        c
+        for c in formatted_geojson.columns
+        if c.startswith("Probability of introduction")
+    ]
+    annual_ts_list = sorted(set([y.split(" ")[-1][:4] for y in prob_intro_cols]))
+    for year in annual_ts_list:
+        formatted_geojson[f"Agg Prob Intro {year}"] = formatted_geojson[
+            f"Probability of introduction {year}"
+        ]
+
+    out_csv = pd.DataFrame(formatted_geojson)
+    out_csv.drop(["geometry"], axis=1, inplace=True)
+    out_csv.to_csv(
+        outpath + "/pandemic_output_aggregated.csv", float_format="%.2f", na_rep="NAN!"
+    )
+    
+
 def write_model_metadata(
     main_model_output,
     alpha,


### PR DESCRIPTION
this is how I resolved the issue of annual runs not generating 'pandemic_output_aggregated.csv' (which we need to run the summary statistics)