### PR TITLE
Add more Black configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,23 @@ jobs:
           flake8 --count --statistics --show-source --jobs=$(nproc) .
 
   black-code-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
-      - name: Check style with Black
+          python-version: "3.10"
+
+      - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          pip install black==21.10b0
+
+      - name: Run Black
+        run: |
           black --check --diff .
 
   pytest-coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 88
+target-version = ['py37', 'py38', 'py39']
+include = '\.pyi?$'
+exclude = '''
+(
+    # exclude directories in the root of the project
+    /(
+          \.eggs
+        | \.git
+        | \.hg
+        | \.mypy_cache
+        | \.tox
+        | \.venv
+        | _build
+        | buck-out
+        | build
+    )/
+)
+'''


### PR DESCRIPTION
This add pyproject.toml which contains Black configuration. It includes the 88 line limit (the default)
and also target versions of Python (target version may change how some things are formatted if the Python syntax is enhanced).

The CI GitHub Action workflow has now whole Black job updated to current versions and it requests a specific Black version.
The Black version is now the current/latest release.
