### PR TITLE
CI: Update conda-based test

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install black==22.3.0
+          pip install black==23.1.0
 
       - name: Run Black
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -13,14 +13,15 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
-          - windows-2019
-          - macos-11
+          - ubuntu-22.04
+          - windows-2022
+          - macos-12
         python-version:
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v2

--- a/Data/GBIF.py
+++ b/Data/GBIF.py
@@ -56,7 +56,6 @@ def call_gbif_api(call):
 
 
 def get_GBIF_records(species, year_list):
-
     species_year = [[species], year_list]
     species_years = list(itertools.product(*species_year))
 

--- a/pandemic/multirun_helpers.py
+++ b/pandemic/multirun_helpers.py
@@ -132,7 +132,6 @@ def create_params(
 def execute_model_runs(
     model_script_path, config_file_path, sim_name, add_descript, run_num, run_type
 ):
-
     """
     Executes a run of the pandemic based on the pandemic script
     location and configuration file location

--- a/tests/test_pandemic.py
+++ b/tests/test_pandemic.py
@@ -5,7 +5,6 @@ from pandemic.model_equations import pandemic_single_time_step
 
 
 def test_pandemic_runs():
-
     trade = np.array([[0, 500, 15], [50, 0, 10], [20, 30, 0]])
     min_Tc = np.min(trade)
     max_Tc = np.max(trade)


### PR DESCRIPTION
- Update all operating systems to latest versions.
- Add Python 3.11 (from Nov 2022).